### PR TITLE
Added: show part behavior on component

### DIFF
--- a/lib/behaviors/base_component_behaviors.dart
+++ b/lib/behaviors/base_component_behaviors.dart
@@ -21,6 +21,11 @@ class BaseComponentBehaviors {
     this.dom_element.style.display = display_value;
   }
 
+  // Show nested element with data-component-part="<part_name>"
+  showPart(part_name, delay) {
+    this.animator.show(this.component.findPart(part_name), delay);
+  }
+
   toggleDisplay() => _toggle(
     [show, hide],
     this.dom_element.style.display == 'none'

--- a/test/behaviors_test.dart
+++ b/test/behaviors_test.dart
@@ -1,6 +1,7 @@
 import '../lib/dartifact.dart';
 import "package:test/test.dart";
 import "dart:html";
+
 part '../lib/test_helpers/component_test_helpers.dart';
 
 @TestOn("browser")
@@ -41,7 +42,7 @@ main() {
     });
 
     group("visibility", () {
-      
+
       test("hides an element", () {
         c.behave('hide');
         expect(el.style.display, equals('none'));
@@ -51,6 +52,16 @@ main() {
         c.dom_element.style.display="none";
         c.behave('show');
         expect(el.style.display, equals('block'));
+      });
+
+      test("shows part element within element", () {
+        var child_component_el = new DivElement();
+        child_component_el.setAttribute('data-component-part', 'my_child_component_part');
+        el.append(child_component_el);
+        c.initChildComponents();
+        child_component_el.style.display="none";
+        c.behave('showPart', ["my_child_component_part", 0]);
+        expect(child_component_el.style.display, equals('block'));
       });
 
       test("shows an element with the specified display value", () {
@@ -70,7 +81,7 @@ main() {
     });
 
     group("locking/unlocking", () {
-      
+
       test("adds 'locked' class to a locked element", () {
         c.behave('lock');
         expect(el.classes, contains('locked'));
@@ -92,7 +103,7 @@ main() {
     });
 
     group("disabling/enabling", () {
-      
+
       test("adds 'disabled' class and attribute to a locked element", () {
         c.behave('disable');
         expect(el.classes,    contains('disabled'));
@@ -117,7 +128,7 @@ main() {
       });
 
     });
-    
+
   });
 
 }


### PR DESCRIPTION
Element needs to be able to show other element(s) with data-component-part within it.
This PR add "showPart" wrapper to easily show "part" elements.