### PR TITLE
Do not handle blur for EditableSelectComponent

### DIFF
--- a/lib/components/editable_select_component.dart
+++ b/lib/components/editable_select_component.dart
@@ -53,8 +53,6 @@ class EditableSelectComponent extends SelectComponent {
 
       "keyup": (self,event) => self.prvt_processInputKeyUpEvent(event),
 
-      "blur":  (self,event) => self.setValueFromManualInput(),
-
       "keydown": (self,event) {
         if(event.keyCode == KeyCode.ENTER)
           event.preventDefault();


### PR DESCRIPTION
Сейчас проблема в том, что blur срабатывает раньше click. 
Это делает невозможным выбор option с помощью клика мышки