### PR TITLE
Sort values in select drop-downs alphabetically

### DIFF
--- a/lib/components/select_component.dart
+++ b/lib/components/select_component.dart
@@ -402,14 +402,18 @@ class SelectComponent extends Component {
     else
       print("Warning: cannot parse the fetched json!");
 
+    // We add this because JSON.decode breaks original hash sorting
+    var sorted_keys = parsed_json.keys.toList(growable:false)..sort((k1, k2) => parsed_json[k1].compareTo(parsed_json[k2]));
+    Map sorted_json = new Map.fromIterable(sorted_keys, key: (k) => k, value: (k) => parsed_json[k]);
+
     // Workaround for dart2js compiler: always keep the `null` option
     // as a first element.
-    if(parsed_json["null"] != null) {
-      var null_option = parsed_json["null"];
-      parsed_json.remove("null");
-      parsed_json = mergeMaps({ "null": null_option }, parsed_json);
+    if(sorted_json["null"] != null) {
+      var null_option = sorted_json["null"];
+      sorted_json.remove("null");
+      sorted_json = mergeMaps({ "null": null_option }, sorted_json);
     }
-    this.options = new LinkedHashMap.from(parsed_json);
+    this.options = new LinkedHashMap.from(sorted_json);
   }
 
   /** This methd is called not once, but every time we fetch new options from the server,

--- a/test/components/select_component_test.dart
+++ b/test/components/select_component_test.dart
@@ -206,6 +206,17 @@ void main() {
       select_comp.http_request_completer.complete("[[\"hello\",{\"display_value\":\"world\",\"some_numbers\": [1,2,3]}]]");
     });
 
+    test("sorts fetched json alphabetically", () {
+      createOptionsInDom();
+      select_comp.fetch_url = "/locations";
+      select_comp.fetchOptions();
+      select_comp.http_request_completer.future.then((response) {
+        expect(select_comp.options.keys, equals(["2","3","1"]));
+        expect(select_comp.options.values, equals(["A","B","C"]));
+      });
+      select_comp.http_request_completer.complete("{\"1\":\"C\",\"2\":\"A\",\"3\":\"B\"}");
+    });
+
     test("re-assigns native click events for newly fetched options in DOM", () {
       createOptionsInDom();
       select_comp.fetch_url = "/locations";


### PR DESCRIPTION
`Json.decode()` automatically sorts json by keys. We cannot control this process. I added alphabetical sorting logic by default in case of my task. But if some user would like to change it he can easily do it. (No need to identify why json sorted by keys)